### PR TITLE
- hiding custom fields across all post types

### DIFF
--- a/plugin_override/general.php
+++ b/plugin_override/general.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * To hold general overrides that span plugins
+ */
+
+/**
+ * Removes the visual display of custom_fields from the WP admin panels
+ *
+ * @since 2022.02.08
+ * @author Curtis
+ *
+ * @param   string    $post_type              The post type being passed
+ * @param   string    $context                The context that the field is being displayed in (side, normal, advanced)
+ * @param   string    $post                   Post object or string that is being operated on
+ * @uses    remove_meta_box()                 Removes the metabox given arguments to target it
+ */
+function proud_remove_default_custom_fields_meta_box( $post_type, $context, $post ) {
+    remove_meta_box( 'postcustom', $post_type, $context );
+}
+add_action( 'do_meta_boxes', 'proud_remove_default_custom_fields_meta_box', 1, 3 );

--- a/wp-proud-core.php
+++ b/wp-proud-core.php
@@ -53,6 +53,7 @@ require_once plugin_dir_path(__FILE__) . 'plugin_override/e-signature/proud-e-si
 require_once plugin_dir_path(__FILE__) . 'plugin_override/gravityformsstripe/proud-gravityformsstripe.php';
 require_once plugin_dir_path(__FILE__) . 'plugin_override/buddydrive/proud-buddydrive.php';
 require_once plugin_dir_path(__FILE__) . 'plugin_override/wordpress-seo/proud-wordpress-seo.php';
+require_once plugin_dir_path(__FILE__) . 'plugin_override/general.php';
 
 use Proud\Core\ProudLibraries as ProudLibraries;
 
@@ -157,7 +158,7 @@ class Proudcore extends \ProudPlugin {
     wp_enqueue_script('proud');
     self::$libraries->loadLibraries();
   }
- 
+
   // Load common libraries
   public function loadAdminLibraries( $hook ) {
     $path = plugins_url('assets/js/',__FILE__);
@@ -217,7 +218,7 @@ class Proudcore extends \ProudPlugin {
   public function restPostOrder( $wp_query ) {
     global $wp;
     $q = add_query_arg(array(),$wp->request);
-    if ( 
+    if (
       $q === 'wp-json/wp/v2/issues' ||
       $q === 'wp-json/wp/v2/questions' ||
       $q === 'wp-json/wp/v2/payments'
@@ -296,27 +297,27 @@ class Proudcore extends \ProudPlugin {
         $sources[$source_size]['url'] = $image_src;
         $media_meta_full = wp_get_attachment_metadata( $attachment_id );
       }
-      // image base name  
+      // image base name
       $image_basename = wp_basename( $image_meta['file'] );
       // upload directory info array
       $upload_dir_info_arr = wp_get_upload_dir();
       // base url of upload directory
       $baseurl = $upload_dir_info_arr['baseurl'];
-      
+
       // Uploads are (or have been) in year/month sub-directories.
       if ( $image_basename !== $image_meta['file'] ) {
         $dirname = dirname( $image_meta['file'] );
-        
+
         if ( $dirname !== '.' ) {
-          $image_baseurl = trailingslashit( trailingslashit( $baseurl ) . $dirname ); 
+          $image_baseurl = trailingslashit( trailingslashit( $baseurl ) . $dirname );
         }
       }
       // Full meta information
       foreach ( $sizes as $size ) {
-        // check whether our custom image size exists in image meta 
+        // check whether our custom image size exists in image meta
         if ( !empty( $image_meta['sizes'][$size] ) ){
           $url = '';
-          
+
           // We have WP stateless option
           if ( isset($media_meta_full) && !empty( $media_meta_full['sizes'][$size]['gs_link'] ) ) {
             $url = $media_meta_full['sizes'][$size]['gs_link'];
@@ -353,7 +354,7 @@ class Proudcore extends \ProudPlugin {
           LEFT JOIN wp_terms t ON r.term_taxonomy_id = t.term_id
           WHERE slug IS NOT NULL
           AND pm.meta_key = %s
-          AND pm.meta_value = %d;', 
+          AND pm.meta_value = %d;',
         '_menu_item_object_id', get_the_ID() ) );
 
         if( !empty($row) ) {


### PR DESCRIPTION
This removes the visual display of custom fields from the WordPress
admin unless someone builds a special field to hold them and save the
data.