### PR TITLE
Add teaser query handling for elasticpress index issue

### DIFF
--- a/modules/proud-teasers/proud-teasers.php
+++ b/modules/proud-teasers/proud-teasers.php
@@ -976,6 +976,16 @@ if ( !class_exists( 'TeaserList' ) ) {
 	 * @uses 	string 			$uniqueID 			required 			Hashed array instance so that we can have a uniqueID for accordions which lets them target the expected parent item or null when it's not defined
      */
     public function print_list( $uniqueID = null ) {
+      // If we are using elasticpress, the running of proud-teaser will alter the index'd post type
+      $elasticEnabled = is_plugin_active('elasticpress/elasticpress.php');
+      if ( $elasticEnabled && did_action( 'save_post' ) > 1 ) {
+        return; 
+      } 
+
+      if ( $elasticEnabled && defined('DOING_AUTOSAVE') && DOING_AUTOSAVE ) {
+        return;
+      }
+
 	  if( $this->query->have_posts() ) {
         $this->print_wrapper_open( $uniqueID );
         if( !empty( $this->featured ) ) {


### PR DESCRIPTION
See https://github.com/proudcity/wp-proudcity/issues/2605 and related discussion: https://proudcity.slack.com/archives/C05517XBZ3P/p1726333296892769

```
The issue is that as the post_content for the page is being generated on post_save, the WP Query initiated for those teasers (events, posts, whatever) via the Siteorigin proud teaser blocks is doing some sort of override on global $post or similar mechanism by the “last” piece of content found on the query.  So by the time the index call actually goes out to elastic, we are getting overridden values for certain fields
```

This PR prevents elasticpress from being initiated on post save.

Things to check 
1. This works on BETA
2. This works on a site with additional caching mechanisms enabled, eg. the page itself loads appropriately.